### PR TITLE
Project Detail View + Update Form

### DIFF
--- a/asset_dashboard/admin.py
+++ b/asset_dashboard/admin.py
@@ -1,3 +1,8 @@
 from django.contrib import admin
+from .models import Project, ProjectCategory, Section, Plan, Staff
 
-# Register your models here.
+admin.site.register(Project)
+admin.site.register(ProjectCategory)
+admin.site.register(Section)
+admin.site.register(Plan)
+admin.site.register(Staff)

--- a/asset_dashboard/forms.py
+++ b/asset_dashboard/forms.py
@@ -1,8 +1,12 @@
-from django.forms import ModelForm, Form, CharField
+from django.forms import ModelForm, CharField
 from django import forms
 from .models import Project, Section
 
-class ProjectForm(Form):
-    name = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}))
-    description = forms.CharField(widget=forms.Textarea(attrs={'class': 'form-control'}))
-    section_owner = forms.ModelChoiceField(queryset=Section.objects.all())
+class ProjectForm(ModelForm):
+    class Meta:
+        model = Project
+        fields = ['name', 'description', 'section_owner']
+        widgets = {
+            'name': forms.TextInput(attrs={'class': 'form-control'}),
+            'description': forms.Textarea(attrs={'class': 'form-control'})
+        }

--- a/asset_dashboard/forms.py
+++ b/asset_dashboard/forms.py
@@ -1,7 +1,8 @@
-from django.forms import ModelForm
-from .models import Project
+from django.forms import ModelForm, Form, CharField
+from django import forms
+from .models import Project, Section
 
-class ProjectForm(ModelForm):
-    class Meta:
-        model = Project
-        fields = ['name', 'description']
+class ProjectForm(Form):
+    name = forms.CharField(widget=forms.TextInput(attrs={'class': 'form-control'}))
+    description = forms.CharField(widget=forms.Textarea(attrs={'class': 'form-control'}))
+    section_owner = forms.ModelChoiceField(queryset=Section.objects.all())

--- a/asset_dashboard/models.py
+++ b/asset_dashboard/models.py
@@ -7,6 +7,9 @@ from django.contrib.gis.db import models
 class Section(models.Model):
     name = models.TextField()
 
+    def __str__(self):
+        return self.name
+
 
 class Staff(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
@@ -66,6 +69,9 @@ class Project(models.Model):
     @property
     def commissioner_districts(self):
         ...
+
+    def __str__(self):
+        return self.name
 
 
 class ProjectScore(models.Model):
@@ -156,6 +162,9 @@ class ProjectCategory(models.Model):
 
     category = models.TextField(null=False)
     subcategory = models.TextField(null=True)
+
+    def __str__(self):
+        return self.category
 
 
 class HouseDistrict(models.Model):

--- a/asset_dashboard/templates/asset_dashboard/base.html
+++ b/asset_dashboard/templates/asset_dashboard/base.html
@@ -80,6 +80,15 @@
       </div>
     </nav>
 
+    {% if messages %}
+      {% for message in messages %}
+        <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %}" role="alert">
+          <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+          {{ message }}
+        </div>
+      {% endfor %}
+    {% endif %}
+
     <main id="main-body" role="main">
       <div class="mt-3 mt-lg-5 mb-5 container">
         {% block body %}{% endblock %}

--- a/asset_dashboard/templates/asset_dashboard/base.html
+++ b/asset_dashboard/templates/asset_dashboard/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>{% block title %}{% endblock %} | CCFP Asset Dashboard</title>
+    <title>{% block title %}Capital Project{% endblock %} | CCFP Asset Dashboard</title>
 
     <meta content="Description TK" name="description" />
     <meta content="Author TK" name="author" />

--- a/asset_dashboard/templates/asset_dashboard/base.html
+++ b/asset_dashboard/templates/asset_dashboard/base.html
@@ -81,7 +81,7 @@
     </nav>
 
     <main id="main-body" role="main">
-      <div class="mt-3 mt-lg-5 mb-5">
+      <div class="mt-3 mt-lg-5 mb-5 container">
         {% block body %}{% endblock %}
       </div>
     </main>
@@ -110,6 +110,7 @@
 
     <!-- Load external scripts -->
     <script src="{% static 'js/jquery.min.js' %}"></script>
+    <script src="{% static 'js/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'js/fontawesome.min.js' %}"></script>
     <script src="{% static 'js/solid.min.js' %}"></script>
 

--- a/asset_dashboard/templates/asset_dashboard/base.html
+++ b/asset_dashboard/templates/asset_dashboard/base.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>{% block title %}Capital Project{% endblock %} | CCFP Asset Dashboard</title>
+    <title>{% block title %}{% endblock %} | CCFP Asset Dashboard</title>
 
     <meta content="Description TK" name="description" />
     <meta content="Author TK" name="author" />

--- a/asset_dashboard/templates/asset_dashboard/partials/add_edit_project_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/add_edit_project_form.html
@@ -1,0 +1,33 @@
+<!-- Modal Form -->
+<div class="modal fade" id="projectForm" tabindex="-1" role="dialog" aria-labelledby="projectFormLabel"
+  aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title" id="projectFormLabel">Add Project</h1>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="container">
+          <div class="row">
+            <div class="w-100">
+              <form action="{% url 'add-edit-projects' %}" method="post">
+                {% csrf_token %}
+                {% for field in form %}
+                  <div class="form-group">
+                    <label class="form-label" for="id_{{ field.name }}">{{ field.label }}</label>
+                    <input class="form-control" type="text" name="{{ field.name }}" required id="id_{{ field.name }}">
+                    <p class="help-text">{{ field.help_text }} </p>
+                  </div>
+                {% endfor %}
+                <input type="submit" value="Add Project" class="btn btn-primary">
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/asset_dashboard/templates/asset_dashboard/partials/add_project_modal_form.html
+++ b/asset_dashboard/templates/asset_dashboard/partials/add_project_modal_form.html
@@ -1,7 +1,6 @@
 <!-- Modal Form -->
-<div class="modal fade" id="projectForm" tabindex="-1" role="dialog" aria-labelledby="projectFormLabel"
-  aria-hidden="true">
-  <div class="modal-dialog" role="document">
+<div class="modal fade" id="projectForm" tabindex="-1" aria-labelledby="projectFormLabel" aria-hidden="true">
+  <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
         <h1 class="modal-title" id="projectFormLabel">Add Project</h1>
@@ -13,13 +12,12 @@
         <div class="container">
           <div class="row">
             <div class="w-100">
-              <form action="{% url 'add-edit-projects' %}" method="post">
+              <form action="{% url 'add-project' %}" method="post">
                 {% csrf_token %}
                 {% for field in form %}
                   <div class="form-group">
                     <label class="form-label" for="id_{{ field.name }}">{{ field.label }}</label>
-                    <input class="form-control" type="text" name="{{ field.name }}" required id="id_{{ field.name }}">
-                    <p class="help-text">{{ field.help_text }} </p>
+                    {{ field }}
                   </div>
                 {% endfor %}
                 <input type="submit" value="Add Project" class="btn btn-primary">

--- a/asset_dashboard/templates/asset_dashboard/project_detail.html
+++ b/asset_dashboard/templates/asset_dashboard/project_detail.html
@@ -2,5 +2,17 @@
 
 {% block body %}
   <h1>{{ project.name }}</h1>
-  <p>{{ project.description }}</p>
+  <nav class="nav">
+    <a class="nav-link active" href="#">Overview</a>
+    <a class="nav-link" href="#">Priority Scoring</a>
+    <a class="nav-link" href="#">Funding</a>
+    <a class="nav-link" href="#">Places</a>
+  </nav>
+  <div class="container card">
+    <form method="post">
+      {% csrf_token %}
+      {{ form }}
+      <input type="submit" value="Update Project" class="btn btn-primary">
+    </form>
+  </div>
 {% endblock %}

--- a/asset_dashboard/templates/asset_dashboard/projects.html
+++ b/asset_dashboard/templates/asset_dashboard/projects.html
@@ -34,4 +34,8 @@
       </tbody>
     </table>
   </div>
+<<<<<<< HEAD
 {% endblock %}
+=======
+{% endblock %}
+>>>>>>> Created a project list view, detail view, and form.

--- a/asset_dashboard/templates/asset_dashboard/projects.html
+++ b/asset_dashboard/templates/asset_dashboard/projects.html
@@ -8,13 +8,14 @@
       <h1 class="col-10">Hey, user!</h1>
       <div class="col-2 d-flex justify-content-center">
         <div>
-          <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#projectForm">Add
-            Project</button>
+          <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#projectForm">
+            Add Project
+          </button>
         </div>
       </div>
     </div>
 
-    {% include "asset_dashboard/partials/add_edit_project_form.html" %}
+    {% include "asset_dashboard/partials/add_project_modal_form.html" %}
 
     <h3>Capital Projects</h3>
     <table class="table">
@@ -34,8 +35,4 @@
       </tbody>
     </table>
   </div>
-<<<<<<< HEAD
 {% endblock %}
-=======
-{% endblock %}
->>>>>>> Created a project list view, detail view, and form.

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -16,12 +16,12 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-from asset_dashboard.views import ProjectListView, Home, AddEditProjectFormView, ProjectDetailView
+from asset_dashboard.views import ProjectListView, Home, ProjectDetailView, AddProjectFormView
 
 urlpatterns = [
     path('', Home.as_view(), name='home'),
     path('projects/', ProjectListView.as_view(), name='projects'),
-    path('projects/add-edit-project/', AddEditProjectFormView.as_view(), name='add-edit-projects'),
+    path('projects/add-project/', AddProjectFormView.as_view(), name='add-project'),
     path('projects/<int:pk>', ProjectDetailView.as_view(), name='project-detail'),
     path('admin/', admin.site.urls),
 ]

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -16,13 +16,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-from asset_dashboard.views import ProjectListView, Home, ProjectDetailView, AddProjectFormView
+from asset_dashboard.views import ProjectListView, Home, AddProjectFormView, ProjectUpdateView
 
 urlpatterns = [
     path('', Home.as_view(), name='home'),
     path('projects/', ProjectListView.as_view(), name='projects'),
     path('projects/add-project/', AddProjectFormView.as_view(), name='add-project'),
-    path('projects/<int:pk>', ProjectDetailView.as_view(), name='project-detail'),
+    path('projects/<int:pk>/update/', ProjectUpdateView.as_view(), name='project-detail'),
     path('admin/', admin.site.urls),
 ]
 

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -49,9 +49,12 @@ class AddProjectFormView(CreateView):
         form = self.form_class(request.POST)
 
         if form.is_valid():
+            print('form is valid!')
             project = Project.objects.create(**form.cleaned_data)
             return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project.pk}))
         else:
+            print(form.errors)
+            print('form is invalid :(')
             return HttpResponseBadRequest('Form is invalid.')
 
 
@@ -63,10 +66,10 @@ class ProjectDetailView(DetailView, edit.FormMixin):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['form'] = ProjectForm(initial={
-            'name': self.object.name,
-            'description': self.object.description,
-            'section_owner': self.object.section_owner.pk
-        })
+                'name': self.object.name,
+                'description': self.object.description,
+                'section_owner': self.object.section_owner.pk
+            })
         return context
 
     # How to make this "put" instead of "post" ?

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -5,6 +5,7 @@ from django.core import serializers
 from django.urls import reverse
 from .models import DummyProject, Project
 from .forms import ProjectForm
+from django.contrib import messages
 
 
 class Home(TemplateView):
@@ -49,12 +50,9 @@ class AddProjectFormView(CreateView):
         form = self.form_class(request.POST)
 
         if form.is_valid():
-            print('form is valid!')
             project = Project.objects.create(**form.cleaned_data)
             return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project.pk}))
         else:
-            print(form.errors)
-            print('form is invalid :(')
             return HttpResponseBadRequest('Form is invalid.')
 
 
@@ -81,4 +79,5 @@ class ProjectDetailView(DetailView, edit.FormMixin):
         if form.is_valid():
 
             project = Project.objects.update(**form.cleaned_data)
+            messages.success(request, 'Project successfully updated!')
             return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': kwargs['pk']}))

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from django.views.generic import TemplateView, ListView, FormView, DetailView, CreateView, edit
+from django.views.generic import TemplateView, ListView, FormView, DetailView, CreateView, UpdateView
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.core import serializers
 from django.urls import reverse
@@ -56,27 +56,14 @@ class AddProjectFormView(CreateView):
             return HttpResponseBadRequest('Form is invalid.')
 
 
-class ProjectDetailView(DetailView, edit.FormMixin):
-    template_name = 'asset_dashboard/project_detail.html'
+class ProjectUpdateView(UpdateView):
     model = Project
+    template_name = 'asset_dashboard/project_detail.html'
     form_class = ProjectForm
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['form'] = ProjectForm(initial={
-                'name': self.object.name,
-                'description': self.object.description,
-                'section_owner': self.object.section_owner.pk
-            })
-        return context
+    def get_success_url(self):
+        return reverse('project-detail', kwargs={'pk': self.kwargs['pk']})
 
-    # How to make this "put" instead of "post" ?
-    # The HTML standard dictates that an HTML form can have
-    # only post and get requests, so a put fails here. 
-    # See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method
-    def post(self, request, *args, **kwargs):
-        form = self.form_class(request.POST)
-        if form.is_valid():
-            project = Project.objects.update(**form.cleaned_data)
-            messages.success(request, 'Project successfully updated!')
-            return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': kwargs['pk']}))
+    def form_valid(self, form):
+        messages.success(self.request, 'Project successfully updated!')
+        return super().form_valid(form)

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from django.views.generic import TemplateView, ListView, FormView, DetailView, CreateView, UpdateView, edit
+from django.views.generic import TemplateView, ListView, FormView, DetailView, CreateView, edit
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.core import serializers
 from django.urls import reverse
@@ -77,7 +77,6 @@ class ProjectDetailView(DetailView, edit.FormMixin):
     def post(self, request, *args, **kwargs):
         form = self.form_class(request.POST)
         if form.is_valid():
-
             project = Project.objects.update(**form.cleaned_data)
             messages.success(request, 'Project successfully updated!')
             return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': kwargs['pk']}))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,11 @@ def project():
     Creates and returns a single project.
     """
 
-    return models.Project.objects.create(name="Trail Maintenance", description="Fixing trail erosion.")
+    section_owner = models.Section.objects.create(name="Architecture")
+
+    return models.Project.objects.create(name="Trail Maintenance", 
+                                        description="Fixing trail erosion.", 
+                                        section_owner=section_owner)
 
 
 @pytest.fixture
@@ -16,9 +20,19 @@ def project_list():
     Creates and returns a QuerySet of all projects.
     """
 
+    section_owner = models.Section.objects.create(name="Civil Engineering")
+
     for index in range(10):
         name = f'project_{index}'
         description = f'description text for this project'
-        models.Project.objects.create(name=name, description=description)
+        models.Project.objects.create(name=name, description=description, section_owner=section_owner)
 
     return models.Project.objects.all()
+
+
+@pytest.fixture
+def section_owner():
+    """
+    Creates and returns a section owner.
+    """
+    return models.Section.objects.create(name="Architecture")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -22,10 +22,7 @@ def test_add_project_view(client, section_owner):
         'section_owner': section_owner.pk
     }
 
-    print(section_owner.pk)
-
     successful_response = client.post(url, data=valid_form_data)
-    print(successful_response)
 
     # assert that the new project saved successfully
     new_project_from_form = Project.objects.filter(name=valid_form_data['name'])[0]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest_django.asserts import assertTemplateUsed, assertHTMLEqual
+from pytest_django.asserts import assertTemplateUsed, assertHTMLEqual, assertContains
 from django.urls import reverse
 from asset_dashboard.models import Project
 
@@ -74,16 +74,8 @@ def test_project_update_view(client, project, project_list, section_owner):
 
     # test that the project updated and renders the updated data to the project ListView
     response = client.get(reverse('projects'))
-    updated_project_name = Project.objects.filter(name=valid_form_data['name'])[0].name
-    name_submitted_with_form = valid_form_data['name']
-    assertHTMLEqual(
-        f'<td>{name_submitted_with_form}</td>',
-        f'<td>{updated_project_name}</td>'
-    )
+    assert valid_form_data['name'] in str(response.context)
 
     # test that the project UpdateView did not overwrite any of the other projects
-    existing_project_name = Project.objects.filter(name='project_0')[0].name
-    assertHTMLEqual(
-        f'<td>{existing_project_name}</td>',
-        f'<td>project_0</td>'
-    )
+    existing_project_name = 'project_0'
+    assert existing_project_name in str(response.context)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -68,9 +68,15 @@ def test_project_update_view(client, project, project_list, section_owner):
         'section_owner': section_owner.pk
     }
     successful_response = client.post(url, data=valid_form_data)
-    updated_project = Project.objects.filter(name=valid_form_data['name'])[0]
-    assert updated_project.name == valid_form_data['name']
-    assert updated_project.description == valid_form_data['description']
+    assert successful_response.status_code == 302
+
+    # test that the form saved the project with correct data
+    updated_project = Project.objects.filter(name=valid_form_data['name'])
+    assert updated_project[0].name == valid_form_data['name']
+    assert updated_project[0].description == valid_form_data['description']
+
+    # test that only one project was updated
+    assert updated_project.count() == 1
 
     # test that the project updated and renders the updated data to the project ListView
     response = client.get(reverse('projects'))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest_django.asserts import assertTemplateUsed
+from pytest_django.asserts import assertTemplateUsed, assertHTMLEqual
 from django.urls import reverse
 from asset_dashboard.models import Project
 
@@ -50,18 +50,18 @@ def test_add_project_view(client, section_owner):
 
 
 @pytest.mark.django_db
-def test_project_detail_view(client, project, section_owner):
+def test_project_update_view(client, project, project_list, section_owner):
     url = reverse('project-detail', kwargs={'pk': project.pk})
     response = client.get(url)
     assert response.status_code == 200
     assert response.context['project'] == project
 
-    # test bad url
+    # test bad url does not exist
     bad_url = reverse('project-detail', kwargs={'pk': 1234556873459})
     bad_response = client.get(bad_url)
     assert bad_response.status_code == 404
 
-    # test that the detail page can update the model instance
+    # test that the project UpdateView can update the model instance
     valid_form_data = {
         'name': 'trail improvement project',
         'description': 'We need to clean the trail, fix some washouts, and build a bathroom.',
@@ -71,3 +71,19 @@ def test_project_detail_view(client, project, section_owner):
     updated_project = Project.objects.filter(name=valid_form_data['name'])[0]
     assert updated_project.name == valid_form_data['name']
     assert updated_project.description == valid_form_data['description']
+
+    # test that the project updated and renders the updated data to the project ListView
+    response = client.get(reverse('projects'))
+    updated_project_name = Project.objects.filter(name=valid_form_data['name'])[0].name
+    name_submitted_with_form = valid_form_data['name']
+    assertHTMLEqual(
+        f'<td>{name_submitted_with_form}</td>',
+        f'<td>{updated_project_name}</td>'
+    )
+
+    # test that the project UpdateView did not overwrite any of the other projects
+    existing_project_name = Project.objects.filter(name='project_0')[0].name
+    assertHTMLEqual(
+        f'<td>{existing_project_name}</td>',
+        f'<td>project_0</td>'
+    )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -32,18 +32,9 @@ def test_add_project_view(client):
     assert successful_response.status_code == 302
 
     # the new project's detail page should be at this route: /projects/<pk:int>
-<<<<<<< HEAD
     # so make sure the new project PK is in the response's redirect url
     assert str(new_project_from_form.pk) in successful_response.url
 
-=======
-    # so make sure the new project PK is in the form's redirect url
-    assert str(new_project_from_form.pk) in successful_response.url
-
-    #assert assertTemplateUsed(successful_response, 'asset_dashboard/project_detail.html')
-    print(successful_response.__dict__)
-
->>>>>>> Created a project list view, detail view, and form.
     invalid_form_data = [
         {'name': '', 'description': ''},
         {'name': ''},

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -13,15 +13,19 @@ def test_project_list_view(client, project_list):
 
 
 @pytest.mark.django_db
-def test_add_project_view(client):
-    url = reverse('add-edit-projects')
+def test_add_project_view(client, section_owner):
+    url = reverse('add-project')
 
     valid_form_data = {
         'name': 'trail maintenance project',
-        'description': 'We need to clean the trail and fix some washouts.'
+        'description': 'We need to clean the trail and fix some washouts.',
+        'section_owner': section_owner.pk
     }
 
+    print(section_owner.pk)
+
     successful_response = client.post(url, data=valid_form_data)
+    print(successful_response)
 
     # assert that the new project saved successfully
     new_project_from_form = Project.objects.filter(name=valid_form_data['name'])[0]
@@ -49,7 +53,7 @@ def test_add_project_view(client):
 
 
 @pytest.mark.django_db
-def test_project_detail_view(client, project):
+def test_project_detail_view(client, project, section_owner):
     url = reverse('project-detail', kwargs={'pk': project.pk})
     response = client.get(url)
     assert response.status_code == 200
@@ -59,3 +63,14 @@ def test_project_detail_view(client, project):
     bad_url = reverse('project-detail', kwargs={'pk': 1234556873459})
     bad_response = client.get(bad_url)
     assert bad_response.status_code == 404
+
+    # test that the detail page can update the model instance
+    valid_form_data = {
+        'name': 'trail improvement project',
+        'description': 'We need to clean the trail, fix some washouts, and build a bathroom.',
+        'section_owner': section_owner.pk
+    }
+    successful_response = client.post(url, data=valid_form_data)
+    updated_project = Project.objects.filter(name=valid_form_data['name'])[0]
+    assert updated_project.name == valid_form_data['name']
+    assert updated_project.description == valid_form_data['description']

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -32,9 +32,18 @@ def test_add_project_view(client):
     assert successful_response.status_code == 302
 
     # the new project's detail page should be at this route: /projects/<pk:int>
+<<<<<<< HEAD
     # so make sure the new project PK is in the response's redirect url
     assert str(new_project_from_form.pk) in successful_response.url
 
+=======
+    # so make sure the new project PK is in the form's redirect url
+    assert str(new_project_from_form.pk) in successful_response.url
+
+    #assert assertTemplateUsed(successful_response, 'asset_dashboard/project_detail.html')
+    print(successful_response.__dict__)
+
+>>>>>>> Created a project list view, detail view, and form.
     invalid_form_data = [
         {'name': '', 'description': ''},
         {'name': ''},


### PR DESCRIPTION
## Overview
This PR has a detail view for a Project model. The user can update the model instance on that page. There is minimal UI styling.

This addresses #14 but the UI lacks additional functionality that was included in the wireframe.

### Demo
![project-detail-demo](https://user-images.githubusercontent.com/38969506/103585967-bd760500-4ea9-11eb-9558-6680abe840d1.gif)


## Testing Instructions
- Visit: https://ccfp-asset-d-project-fo-nyyvqi.herokuapp.com/projects/
- Add a new project
- Upon success, you'll be redirected to the new project's detail page
- Edit some of the fields and save
- You should see a flash message that it was successful
- Go back to https://ccfp-asset-d-project-fo-nyyvqi.herokuapp.com/projects/ and verify that it updated successfully