### PR TITLE
Created a basic view, template, and url for #41

### DIFF
--- a/asset_dashboard/templates/asset_dashboard/base.html
+++ b/asset_dashboard/templates/asset_dashboard/base.html
@@ -48,6 +48,7 @@
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
           <a class="dropdown-item text-primary" href="{% url 'projects' %}">Projects</a>
           <a class="dropdown-item text-primary" href="{% url 'cip-planner' %}">CIP Planner</a>
+          <a class="dropdown-item text-primary" href="{% url 'projects-by-detail' %}">Projects by District</a>
           <div class="dropdown-divider"></div>
           <a class="dropdown-item text-primary" href="{% url 'admin:index' %}">Admin</a>
       </div>

--- a/asset_dashboard/templates/asset_dashboard/projects_by_district_list.html
+++ b/asset_dashboard/templates/asset_dashboard/projects_by_district_list.html
@@ -32,10 +32,12 @@
                   <td>{{ project.category }}</td>
 
                   <!-- TODO: show the list of district names. 
-                    i need advice on how to do this. each district returns a queryset.
-                    somehow, a project's list of districts need to be combined for display
-                    in the table. it could look like: Senate 17, Senate 18 or 17, 18.
-                    should i parse out each district in the template or create a model method to do this? -->
+                    i need advice on how to do this. each district returns a queryset, so
+                    a project's list of districts need to be combined for display
+                    in the table. it could look like either: 
+                        Senate 17, Senate 18
+                        17, 18
+                    to do this, should i parse out each district in the template or create a model method? -->
                   <td>senate</td>
                   <td>house</td>
                   <td>commissioner</td>

--- a/asset_dashboard/templates/asset_dashboard/projects_by_district_list.html
+++ b/asset_dashboard/templates/asset_dashboard/projects_by_district_list.html
@@ -1,0 +1,49 @@
+{% extends "asset_dashboard/base.html" %}
+{% load static %}
+
+{% block title %}Projects by District{% endblock %}
+
+{% block body %}
+  <div>
+      <div class="card mt-4 p-4 col-12 col-lg-10 mx-auto shadow-sm">
+        <div class="card-body table-responsive">
+          <div class="row text-left">
+            <h1 class="col-8">Projects by District</h1>
+          </div>
+
+          <!-- TODO: add filtering and searching, with javascript -->
+
+          <table class="table table-hover table-border py-4 dataTable no-footer" id="project-by-district-list-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th>Category</th>
+                <th>Senate District</th>
+                <th>House District</th>
+                <th>Commissioner District</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for project in projects %}
+                <tr>
+                  <td>{{ project.name }}</td>
+                  <td>{{ project.description }}</td>
+                  <td>{{ project.category }}</td>
+
+                  <!-- TODO: show the list of district names. 
+                    i need advice on how to do this. each district returns a queryset.
+                    somehow, a project's list of districts need to be combined for display
+                    in the table. it could look like: Senate 17, Senate 18 or 17, 18.
+                    should i parse out each district in the template or create a model method to do this? -->
+                  <td>senate</td>
+                  <td>house</td>
+                  <td>commissioner</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+  </div>
+{% endblock %}

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -16,14 +16,15 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
-from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreateView, ProjectUpdateView, ProjectListJson
+from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreateView, ProjectUpdateView, ProjectListJson, ProjectsByDistrictListView
 
 urlpatterns = [
     path('', ProjectListView.as_view(), name='projects'),
-    path('projects/json', ProjectListJson.as_view(), name='project-list-json'),
+    path('projects/json/', ProjectListJson.as_view(), name='project-list-json'),
     path('projects/add-project/', ProjectCreateView.as_view(), name='add-project'),
     path('projects/<int:pk>/', ProjectUpdateView.as_view(), name='project-detail'),
-    path('cip-planner', CipPlannerView.as_view(), name='cip-planner'),
+    path('projects/districts/', ProjectsByDistrictListView.as_view(), name='projects-by-detail'),
+    path('cip-planner/', CipPlannerView.as_view(), name='cip-planner'),
     path('admin/', admin.site.urls),
 ]
 

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -20,11 +20,11 @@ from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreate
 
 urlpatterns = [
     path('', ProjectListView.as_view(), name='projects'),
-    path('projects/json/', ProjectListJson.as_view(), name='project-list-json'),
+    path('projects/json', ProjectListJson.as_view(), name='project-list-json'),
     path('projects/add-project/', ProjectCreateView.as_view(), name='add-project'),
     path('projects/<int:pk>/', ProjectUpdateView.as_view(), name='project-detail'),
     path('projects/districts/', ProjectsByDistrictListView.as_view(), name='projects-by-detail'),
-    path('cip-planner/', CipPlannerView.as_view(), name='cip-planner'),
+    path('cip-planner', CipPlannerView.as_view(), name='cip-planner'),
     path('admin/', admin.site.urls),
 ]
 

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -1,5 +1,4 @@
 import json
-from typing import List
 from django.core.serializers.json import DjangoJSONEncoder
 from django.shortcuts import render
 from django.views.generic import TemplateView, ListView, CreateView, UpdateView

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -1,4 +1,5 @@
 import json
+from typing import List
 from django.core.serializers.json import DjangoJSONEncoder
 from django.shortcuts import render
 from django.views.generic import TemplateView, ListView, CreateView, UpdateView
@@ -167,3 +168,9 @@ class ProjectUpdateView(UpdateView):
 
         messages.success(self.request, 'Project successfully saved!')
         return super().form_valid(form)
+
+
+class ProjectsByDistrictListView(ListView):
+    template_name = 'asset_dashboard/projects_by_district_list.html'
+    queryset = Project.objects.all()
+    context_object_name = 'projects'


### PR DESCRIPTION
## Overview
This is the first step for #41. The implementation is basic and the feature incomplete.

The PR includes:
- a new view for listing projects that are filterable by district
- url for the view
- a link in the menu for the new url
- template for the view

### Demo
![district-list-view](https://user-images.githubusercontent.com/38969506/108274031-fd333c00-7139-11eb-895d-a05d7856c62d.gif)

### Notes
I was thinking that I would do this filtering like I've done with the project list view. I used the [datatables jquery plugin](https://datatables.net/) for the UI and [django-datatables-view](https://pypi.org/project/django-datatables-view/) for the Django view.

The districts are hardcoded in the table, so they aren't using real data. There's a note in the code about that.

I'm not sure what to call this, especially since a project list view already exists (with filtering). I landed on "projects by district". We could stuff this functionality into the existing project list table but it might be too much in one table...thoughts on this?

## Testing Instructions
- Visit the deployment. You'll need to add a project so one shows up in the new table.
- In the dropdown menu, click on the "Projects by Districts"
- See the table with the projects. 
