### PR TITLE
Adds project filtering by district

### DIFF
--- a/asset_dashboard/static/js/districtFilterTable.js
+++ b/asset_dashboard/static/js/districtFilterTable.js
@@ -6,24 +6,24 @@ $(document).ready(function() {
             {
                 name: 'name',
                 orderable: true,
-                searchable: true,
+                searchable: false,
                 targets: [0]
             },
             {
                 name: 'description',
                 orderable: true,
-                searchable: true,
+                searchable: false,
                 targets: [1],
             },
             {
                 name: 'senate_districts',
-                orderable: true,
+                orderable: false,
                 searchable: false,
                 targets: [2]
             },
             {
                 name: 'house_districts',
-                orderable: true,
+                orderable: false,
                 searchable: false,
                 targets: [3]
             },

--- a/asset_dashboard/static/js/districtFilterTable.js
+++ b/asset_dashboard/static/js/districtFilterTable.js
@@ -1,0 +1,107 @@
+$(document).ready(function() {
+    var table = $('#project-by-district-list').DataTable({
+        serverSide: true,
+        ajax: 'json/',
+        columns: [
+            {
+                name: 'name',
+                orderable: true,
+                searchable: true,
+                targets: [0]
+            },
+            {
+                name: 'description',
+                orderable: true,
+                searchable: true,
+                targets: [1],
+            },
+            {
+                name: 'senate_districts',
+                orderable: true,
+                searchable: false,
+                targets: [2]
+            },
+            {
+                name: 'house_districts',
+                orderable: true,
+                searchable: false,
+                targets: [3]
+            },
+            {
+                name: 'commissioner_districts',
+                orderable: false,
+                searchable: false,
+                visible: true,
+                targets: [4]
+            },
+            {
+                name: 'id',
+                orderable: false,
+                searchable: false,
+                visible: false,
+                targets: [5]
+            },
+        ],
+
+        // custom styles on some parts of the table
+        // see https://datatables.net/reference/option/dom
+        dom: "<'row'<'col-sm-12'tr>>" +
+            "<'row'<'col'l><'col'i><'col'p>>",
+
+        // add callback functions to the select widgets for filtering
+        initComplete: function () {
+            this.api().columns().every( function () {
+                let column = this;
+                let columnHeaderName = column.header().textContent
+
+                const idSelectorName = columnHeaderName.toLowerCase().split(' ')[0]
+                console.log('idSelectorName', idSelectorName)
+
+                const idSelectorsForFiltering = [
+                    'senate',
+                    'house',
+                    'commissioner'
+                ]
+
+                if (idSelectorsForFiltering.includes(idSelectorName)) {
+                    // add a callback to the html page's existing <select> 
+                    $(`#${idSelectorName}-select`).on('change', function() {
+                        let val = $.fn.dataTable.util.escapeRegex(
+                          $(this).val()
+                        );
+  
+                        return column.search(val ? val : '', true, false).draw();
+                      });
+                }
+
+                    
+            });
+        },
+        
+        // make each row clickable for redirecting to the detail page
+        fnRowCallback: function (row, data) {
+            const projectId = data[5]
+
+            // add the id as an attribute to the <tr> element
+            $(row).data('project-id', projectId)
+
+            // show the cursor pointer when a user hovers over the row
+            // so they know they can click on it
+            $(row).addClass('cursor-pointer')
+
+            return row
+        }
+    });
+
+    // listen to click event for redirecting to a project detail page
+    $('#project-by-district-list tbody').on('click', 'tr', function () {
+        const id = $(this).data('project-id')
+        window.location = id ? '/projects/' + id : ''
+    })
+
+    // styling configuration for the table's pagination components
+    $('div.dataTables_length').addClass('pt-3');
+    $('div.dataTables_length label').addClass('d-flex flex-row');
+    $('div.dataTables_paginate').addClass('pt-1');
+    $('div.dataTables_info').addClass('text-center')
+  });

--- a/asset_dashboard/static/js/districtFilterTable.js
+++ b/asset_dashboard/static/js/districtFilterTable.js
@@ -55,7 +55,6 @@ $(document).ready(function() {
                 let columnHeaderName = column.header().textContent
 
                 const idSelectorName = columnHeaderName.toLowerCase().split(' ')[0]
-                console.log('idSelectorName', idSelectorName)
 
                 const idSelectorsForFiltering = [
                     'senate',
@@ -103,5 +102,5 @@ $(document).ready(function() {
     $('div.dataTables_length').addClass('pt-3');
     $('div.dataTables_length label').addClass('d-flex flex-row');
     $('div.dataTables_paginate').addClass('pt-1');
-    $('div.dataTables_info').addClass('text-center')
+    $('div.dataTables_info').addClass('text-center');
   });

--- a/asset_dashboard/templates/asset_dashboard/projects_by_district_list.html
+++ b/asset_dashboard/templates/asset_dashboard/projects_by_district_list.html
@@ -8,11 +8,11 @@
       <div class="card mt-4 p-4 col-12 col-lg-10 mx-auto shadow-sm">
         <div class="card-body table-responsive">
           <div class="row text-left">
-            <h1 class="col-8">Projects by District</h1>
+            <h3 class="col-8">View Projects by District</h3>
           </div>
 
           <!-- these elements filter the table, with the help of javascript -->
-          <div class="row d-flex justify-content-around">
+          <div class="row d-flex justify-content-around mt-4">
             <select class="form-control col-lg-3 col-md-12 m-1" id="senate-select">
               <option value="" disabled selected >
                 Filter by Senate District

--- a/asset_dashboard/templates/asset_dashboard/projects_by_district_list.html
+++ b/asset_dashboard/templates/asset_dashboard/projects_by_district_list.html
@@ -11,41 +11,60 @@
             <h1 class="col-8">Projects by District</h1>
           </div>
 
-          <!-- TODO: add filtering and searching, with javascript -->
+          <!-- these elements filter the table, with the help of javascript -->
+          <div class="row d-flex justify-content-around">
+            <select class="form-control col-lg-3 col-md-12 m-1" id="senate-select">
+              <option value="" disabled selected >
+                Filter by Senate District
+              </option>
+              {% for district in senate_districts %}
+                <option>
+                  {{ district.name }}
+                </option>
+              {% endfor %}
+            </select>
 
-          <table class="table table-hover table-border py-4 dataTable no-footer" id="project-by-district-list-table">
+              <select class="form-control col-lg-3 col-md-12 m-1" id="house-select">
+                <option value="" disabled selected >
+                  Filter by House District
+                </option>
+                {% for district in house_districts %}
+                  <option>
+                    {{ district.name }}
+                  </option>
+                {% endfor %}
+              </select>
+
+              <select class="form-control col-lg-3 col-md-12 m-1" id="commissioner-select">
+                <option value="" disabled selected >
+                  Filter by Commissioner District
+                </option>
+                {% for district in commissioner_districts %}
+                  <option>
+                    {{ district.name }}
+                  </option>
+                {% endfor %}
+              </select>
+          </div>
+
+          <table class="table table-hover table-border py-4 dataTable no-footer" id="project-by-district-list">
             <thead>
               <tr>
                 <th>Name</th>
                 <th>Description</th>
-                <th>Category</th>
-                <th>Senate District</th>
-                <th>House District</th>
-                <th>Commissioner District</th>
+                <th>Senate Districts</th>
+                <th>House Districts</th>
+                <th>Commissioner Districts</th>
               </tr>
             </thead>
             <tbody>
-              {% for project in projects %}
-                <tr>
-                  <td>{{ project.name }}</td>
-                  <td>{{ project.description }}</td>
-                  <td>{{ project.category }}</td>
-
-                  <!-- TODO: show the list of district names. 
-                    i need advice on how to do this. each district returns a queryset, so
-                    a project's list of districts need to be combined for display
-                    in the table. it could look like either: 
-                        Senate 17, Senate 18
-                        17, 18
-                    to do this, should i parse out each district in the template or create a model method? -->
-                  <td>senate</td>
-                  <td>house</td>
-                  <td>commissioner</td>
-                </tr>
-              {% endfor %}
             </tbody>
           </table>
         </div>
       </div>
   </div>
+{% endblock %}
+
+{% block extra_js %}
+  <script type="text/javascript" src="{% static 'js/districtFilterTable.js' %}"></script>
 {% endblock %}

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
-from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreateView, ProjectUpdateView, ProjectListJson, ProjectsByDistrictListView
+from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreateView, ProjectUpdateView, ProjectListJson, ProjectsByDistrictListView, ProjectsByDistrictListJson
 
 urlpatterns = [
     path('', ProjectListView.as_view(), name='projects'),
@@ -24,6 +24,7 @@ urlpatterns = [
     path('projects/add-project/', ProjectCreateView.as_view(), name='add-project'),
     path('projects/<int:pk>/', ProjectUpdateView.as_view(), name='project-detail'),
     path('projects/districts/', ProjectsByDistrictListView.as_view(), name='projects-by-detail'),
+    path('projects/districts/json/', ProjectsByDistrictListJson.as_view(), name='projects-district-json'),
     path('cip-planner', CipPlannerView.as_view(), name='cip-planner'),
     path('admin/', admin.site.urls),
 ]

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -16,7 +16,9 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
-from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreateView, ProjectUpdateView, ProjectListJson, ProjectsByDistrictListView, ProjectsByDistrictListJson
+from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreateView, \
+                                    ProjectUpdateView, ProjectListJson, \
+                                    ProjectsByDistrictListView, ProjectsByDistrictListJson
 
 urlpatterns = [
     path('', ProjectListView.as_view(), name='projects'),

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -232,7 +232,7 @@ class ProjectsByDistrictListJson(BaseDatatableView):
     def format_district_names(self, districts):
         """Parses a queryset of districts into something consumable by the table library."""
 
-        # create a string w/ names separated by commma
+        # create a string with names separated by commma
         district_names = ', '.join([d.name for d in districts.all()])
 
         # only return the district's number and comma/space between numbers

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -175,14 +175,14 @@ class ProjectsByDistrictListView(ListView):
     template_name = 'asset_dashboard/projects_by_district_list.html'
     queryset = Project.objects.all()
     context_object_name = 'projects'
-    
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        
+
         context['senate_districts'] = SenateDistrict.objects.all()
         context['house_districts'] = HouseDistrict.objects.all()
         context['commissioner_districts'] = CommissionerDistrict.objects.all()
-        
+
         return context
 
 
@@ -202,7 +202,7 @@ class ProjectsByDistrictListJson(BaseDatatableView):
 
         if house_district:
             qs = qs.filter(house_districts__name=house_district)
-            
+
         if commissioner_district:
             qs = qs.filter(commissioner_districts__name=commissioner_district)
 
@@ -212,7 +212,7 @@ class ProjectsByDistrictListJson(BaseDatatableView):
         # prepare list with output column data
         # queryset is already paginated here
         json_data = []
-        
+
         for item in qs:
             senate_districts = self.format_district_names(item.senate_districts)
             house_districts = self.format_district_names(item.house_districts)
@@ -226,16 +226,14 @@ class ProjectsByDistrictListJson(BaseDatatableView):
                 escape(commissioner_districts),
                 item.id
             ])
-            
+
         return json_data
-    
-    
+
     def format_district_names(self, districts):
         """Parses a queryset of districts into something consumable by the table library."""
-        
+
         # create a string w/ names separated by commma
         district_names = ', '.join([d.name for d in districts.all()])
-        
+
         # only return the district's number and comma/space between numbers
         return re.sub('[^0-9, ]', '', district_names)
-        

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -1,14 +1,16 @@
 import json
+import re
 from django.core.serializers.json import DjangoJSONEncoder
 from django.shortcuts import render
 from django.views.generic import TemplateView, ListView, CreateView, UpdateView
 from django_datatables_view.base_datatable_view import BaseDatatableView
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from .models import Project, ProjectCategory, ProjectFinances, ProjectScore, Section
+from .models import HouseDistrict, Project, ProjectCategory, ProjectFinances, ProjectScore, Section, SenateDistrict, CommissionerDistrict
 from .forms import ProjectForm, ProjectScoreForm, ProjectCategoryForm, ProjectFinancesForm
 from django.contrib import messages
 from django.db.models import Q
+from django.utils.html import escape
 
 
 class CipPlannerView(TemplateView):
@@ -173,3 +175,67 @@ class ProjectsByDistrictListView(ListView):
     template_name = 'asset_dashboard/projects_by_district_list.html'
     queryset = Project.objects.all()
     context_object_name = 'projects'
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        
+        context['senate_districts'] = SenateDistrict.objects.all()
+        context['house_districts'] = HouseDistrict.objects.all()
+        context['commissioner_districts'] = CommissionerDistrict.objects.all()
+        
+        return context
+
+
+class ProjectsByDistrictListJson(BaseDatatableView):
+    model = Project
+    columns = ['name', 'description', 'senate_districts', 'house_districts', 'commissioner_districts', 'id']
+    order_columns = ['name', 'description']
+    max_display_length = 500
+
+    def filter_queryset(self, qs):
+        senate_district = self.request.GET.get('columns[2][search][value]', None)
+        house_district = self.request.GET.get('columns[3][search][value]', None)
+        commissioner_district = self.request.GET.get('columns[4][search][value]', None)
+
+        if senate_district:
+            qs = qs.filter(senate_districts__name=senate_district)
+
+        if house_district:
+            qs = qs.filter(house_districts__name=house_district)
+            
+        if commissioner_district:
+            qs = qs.filter(commissioner_districts__name=commissioner_district)
+
+        return qs
+
+    def prepare_results(self, qs):
+        # prepare list with output column data
+        # queryset is already paginated here
+        json_data = []
+        
+        for item in qs:
+            senate_districts = self.format_district_names(item.senate_districts)
+            house_districts = self.format_district_names(item.house_districts)
+            commissioner_districts = self.format_district_names(item.commissioner_districts)
+
+            json_data.append([
+                escape(item.name),
+                escape(item.description),
+                escape(senate_districts),
+                escape(house_districts),
+                escape(commissioner_districts),
+                item.id
+            ])
+            
+        return json_data
+    
+    
+    def format_district_names(self, districts):
+        """Parses a queryset of districts into something consumable by the table library."""
+        
+        # create a string w/ names separated by commma
+        district_names = ', '.join([d.name for d in districts.all()])
+        
+        # only return the district's number and comma/space between numbers
+        return re.sub('[^0-9, ]', '', district_names)
+        


### PR DESCRIPTION
## Overview
Adds filtering to the table. Users can filter projects based on Senate, House, and Commissioner districts.

Closes #41.

### Demo
![district-filtering](https://user-images.githubusercontent.com/38969506/108759653-40165a80-7512-11eb-94c0-407f3980492d.gif)


## Testing Instructions
- Visit review app. Add a project and then update the project to have some districts.
- Go to `/projects/districts/`. 
- Filter the projects in the table.
