### PR TITLE
Url bug fix

### DIFF
--- a/asset_dashboard/static/js/projectDataTable.js
+++ b/asset_dashboard/static/js/projectDataTable.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
     var table = $('#project-list-table').DataTable({
         serverSide: true,
-        ajax: 'projects/json',
+        ajax: 'projects/json/',
         columns: [
             {
                 name: 'name',

--- a/asset_dashboard/templates/asset_dashboard/base.html
+++ b/asset_dashboard/templates/asset_dashboard/base.html
@@ -48,7 +48,7 @@
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
           <a class="dropdown-item text-primary" href="{% url 'projects' %}">Projects</a>
           <a class="dropdown-item text-primary" href="{% url 'cip-planner' %}">CIP Planner</a>
-          <a class="dropdown-item text-primary" href="{% url 'projects-by-detail' %}">Projects by District</a>
+          <a class="dropdown-item text-primary" href="{% url 'projects-by-district' %}">Projects by District</a>
           <div class="dropdown-divider"></div>
           <a class="dropdown-item text-primary" href="{% url 'admin:index' %}">Admin</a>
       </div>

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     path('projects/json/', ProjectListJson.as_view(), name='project-list-json'),
     path('projects/add-project/', ProjectCreateView.as_view(), name='add-project'),
     path('projects/<int:pk>/', ProjectUpdateView.as_view(), name='project-detail'),
-    path('projects/districts/', ProjectsByDistrictListView.as_view(), name='projects-by-detail'),
+    path('projects/districts/', ProjectsByDistrictListView.as_view(), name='projects-by-district'),
     path('projects/districts/json/', ProjectsByDistrictListJson.as_view(), name='projects-district-json'),
     path('cip-planner/', CipPlannerView.as_view(), name='cip-planner'),
     path('admin/', admin.site.urls),

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -22,7 +22,7 @@ from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreate
 
 urlpatterns = [
     path('', ProjectListView.as_view(), name='projects'),
-    path('projects/json', ProjectListJson.as_view(), name='project-list-json'),
+    path('projects/json/', ProjectListJson.as_view(), name='project-list-json'),
     path('projects/add-project/', ProjectCreateView.as_view(), name='add-project'),
     path('projects/<int:pk>/', ProjectUpdateView.as_view(), name='project-detail'),
     path('projects/districts/', ProjectsByDistrictListView.as_view(), name='projects-by-detail'),

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -27,7 +27,7 @@ urlpatterns = [
     path('projects/<int:pk>/', ProjectUpdateView.as_view(), name='project-detail'),
     path('projects/districts/', ProjectsByDistrictListView.as_view(), name='projects-by-detail'),
     path('projects/districts/json/', ProjectsByDistrictListJson.as_view(), name='projects-district-json'),
-    path('cip-planner', CipPlannerView.as_view(), name='cip-planner'),
+    path('cip-planner/', CipPlannerView.as_view(), name='cip-planner'),
     path('admin/', admin.site.urls),
 ]
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -30,7 +30,7 @@ def test_project_list_json(client, project_list):
     #
     # a request to filter based on "section" will have a query string like this:
     #
-    #   http://localhost:8000/projects/json?draw=2&columns[2][data]=2&columns[2][name]=section_owner
+    #   http://localhost:8000/projects/json/?draw=2&columns[2][data]=2&columns[2][name]=section_owner
     #                           &columns[2][searchable]=true&columns[2][orderable]=true
     #                           &columns[2][search][value]=Architecture&columns[2][search][regex]=true
     #
@@ -54,7 +54,7 @@ def test_project_list_json(client, project_list):
     # iterate through the project_list to get each project's section owner
     for project in project_list:
         section = project.section_owner
-        url_with_section_params = f'/projects/json?draw=2&columns[2][data]=2&columns[2][name]=section_owner \
+        url_with_section_params = f'/projects/json/?draw=2&columns[2][data]=2&columns[2][name]=section_owner \
                             &columns[2][searchable]=true&columns[2][orderable]=true \
                             &columns[2][search][value]={section.name}&columns[2][search][regex]=true'
 
@@ -69,7 +69,7 @@ def test_project_list_json(client, project_list):
 
     # test the filtering for a project category
     for category in ProjectCategory.objects.all():
-        url_with_category_filter = f'/projects/json?draw=3&columns[3][data]=3&columns[3][name]=category \
+        url_with_category_filter = f'/projects/json/?draw=3&columns[3][data]=3&columns[3][name]=category \
                                     &columns[3][searchable]=false&columns[3][orderable]=true \
                                     &columns[3][search][value]={category}&columns[3][search][regex]=true'
 
@@ -83,7 +83,7 @@ def test_project_list_json(client, project_list):
                         
     # test that the response returns no data if data doesn't exist (effectively filtering out everything)
     nonexistent_section_name = 'nonexistent section'
-    url_params_for_nonexistent_section = f'/projects/json?draw=2&columns[2][data]=2&columns[2][name]=section_owner \
+    url_params_for_nonexistent_section = f'/projects/json/?draw=2&columns[2][data]=2&columns[2][name]=section_owner \
                         &columns[2][searchable]=true&columns[2][orderable]=true \
                         &columns[2][search][value]={nonexistent_section_name}&columns[2][search][regex]=true'
                         


### PR DESCRIPTION
## Overview
Fixes a bug I noticed while working on another task. Closes #43.

- adds trailing backslash to `/projects/json` and `/cip-planner`
- changed name for a url

## Testing Instructions
- tests should run
- should be able to see the project list table and filter without any problems
