### PR TITLE
turned on django-compressor's offline compression

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ COPY . /app
 # Add a bogus env var for the Django secret key in order to allow us to run
 # the 'collectstatic' management command
 ENV DJANGO_SECRET_KEY 'foobar'
+ENV DJANGO_DEBUG 'False'
 
 # Build static files into the container
 RUN python manage.py collectstatic --noinput
+RUN python manage.py compress --traceback

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,9 @@ COPY . /app
 # Add a bogus env var for the Django secret key in order to allow us to run
 # the 'collectstatic' management command
 ENV DJANGO_SECRET_KEY 'foobar'
+# Add a bogus env var for Debug to make sure that Django compressor can run
 ENV DJANGO_DEBUG 'False'
 
 # Build static files into the container
 RUN python manage.py collectstatic --noinput
-RUN python manage.py compress --traceback
+RUN python manage.py compress

--- a/asset_dashboard/settings.py
+++ b/asset_dashboard/settings.py
@@ -14,6 +14,7 @@ import os
 import dj_database_url
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+from django.templatetags.static import static
 
 from asset_dashboard.logging import before_send
 
@@ -170,6 +171,9 @@ COMPRESS_ENABLED = True
 
 # Enable offline compression in production only
 COMPRESS_OFFLINE = not DEBUG
+
+# Make sure Django compressor can generate static paths
+COMPRESSOR_OFFLINE_CONTEXT = {'static': static}
 
 # Enforce SSL in production
 if DEBUG is False:

--- a/asset_dashboard/settings.py
+++ b/asset_dashboard/settings.py
@@ -165,15 +165,13 @@ COMPRESS_PRECOMPILERS = (
 
 COMPRESS_OUTPUT_DIR = 'compressor'
 
-# Defaults to the opposite of DEBUG. 
-# DEBUG == False in production.
 COMPRESS_ENABLED = True
 
 # Enable offline compression in production only
 COMPRESS_OFFLINE = not DEBUG
 
 # Make sure Django compressor can generate static paths
-COMPRESS_OFFLINE_CONTEXT = { 'static': static }
+COMPRESS_OFFLINE_CONTEXT = {'static': static}
 
 # Enforce SSL in production
 if DEBUG is False:

--- a/asset_dashboard/settings.py
+++ b/asset_dashboard/settings.py
@@ -30,7 +30,7 @@ DEBUG = False if os.getenv('DJANGO_DEBUG', True) == 'False' else True
 # Define DJANGO_ALLOWED_HOSTS as a comma-separated list of valid hosts,
 # e.g. localhost,127.0.0.1,.herokuapp.com
 allowed_hosts = os.getenv('DJANGO_ALLOWED_HOSTS', [])
-ALLOWED_HOSTS = allowed_hosts.split(',') if allowed_hosts else []
+ALLOWED_HOSTS = allowed_hosts.split(',') if allowed_hosts else ['localhost']
 
 
 # Configure Sentry for error logging
@@ -173,7 +173,7 @@ COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = not DEBUG
 
 # Make sure Django compressor can generate static paths
-COMPRESSOR_OFFLINE_CONTEXT = {'static': static}
+COMPRESS_OFFLINE_CONTEXT = { 'static': static }
 
 # Enforce SSL in production
 if DEBUG is False:

--- a/asset_dashboard/settings.py
+++ b/asset_dashboard/settings.py
@@ -30,7 +30,7 @@ DEBUG = False if os.getenv('DJANGO_DEBUG', True) == 'False' else True
 # Define DJANGO_ALLOWED_HOSTS as a comma-separated list of valid hosts,
 # e.g. localhost,127.0.0.1,.herokuapp.com
 allowed_hosts = os.getenv('DJANGO_ALLOWED_HOSTS', [])
-ALLOWED_HOSTS = allowed_hosts.split(',') if allowed_hosts else ['localhost']
+ALLOWED_HOSTS = allowed_hosts.split(',') if allowed_hosts else []
 
 
 # Configure Sentry for error logging

--- a/asset_dashboard/settings.py
+++ b/asset_dashboard/settings.py
@@ -164,6 +164,13 @@ COMPRESS_PRECOMPILERS = (
 
 COMPRESS_OUTPUT_DIR = 'compressor'
 
+# Defaults to the opposite of DEBUG. 
+# DEBUG == False in production.
+COMPRESS_ENABLED = True
+
+# Enable offline compression in production only
+COMPRESS_OFFLINE = not DEBUG
+
 # Enforce SSL in production
 if DEBUG is False:
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/asset_dashboard/templates/asset_dashboard/planner.html
+++ b/asset_dashboard/templates/asset_dashboard/planner.html
@@ -23,6 +23,6 @@
   window.reactMount = document.getElementById('App')
 </script>
 {% compress js %}
-  <script type="text/jsx" src="{% static view.component %}"></script>
+  <script type="text/jsx" src="{% static 'js/planner.js' %}"></script>
 {% endcompress %}
 {% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       DJANGO_SECRET_KEY: reallysupersecret
       DJANGO_MANAGEPY_MIGRATE: "on"
+      DJANGO_DEBUG: "True"
     entrypoint: /app/docker-entrypoint.sh
     command: python manage.py runserver 0.0.0.0:8000
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,7 +4,6 @@
 set -euo pipefail
 
 python manage.py collectstatic --noinput
-python manage.py compress --traceback
 python manage.py migrate --noinput
 python manage.py createcachetable && python manage.py clear_cache
 python manage.py loaddata asset_dashboard/fixtures/data.json

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 python manage.py collectstatic --noinput
+python manage.py compress --traceback
 python manage.py migrate --noinput
 python manage.py createcachetable && python manage.py clear_cache
 python manage.py loaddata asset_dashboard/fixtures/data.json


### PR DESCRIPTION
## Overview
This PR configures the django-compressor to do offline compression when it's deployed to Heroku. I followed the Docker/compressor patterns in https://github.com/datamade/california-dream-index to fix this.

Closes issue #51.

### Notes
While working on this, I found that the offline compressor wouldn't run because [the template was pointing at view.component](https://github.com/datamade/ccfp-asset-dashboard/blob/master/asset_dashboard/templates/asset_dashboard/planner.html#L26), which was undefined when the compressor ran. So I changed that reference to a string of the path to the javascript code and now it works.

This also fixed a flaw I've noticed. In the past, after deploying to Heroku, the CIP Planner would take a few seconds to load. Now the page loads quicker because the compression happens whenever the app image builds.

## Testing Instructions
- visit the review app
- go to `/cip-planner` and make sure it loads
