### PR TITLE
Added user authentication

### DIFF
--- a/asset_dashboard/settings.py
+++ b/asset_dashboard/settings.py
@@ -52,7 +52,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'compressor',
     'djmoney',
-    'asset_dashboard'
+    'asset_dashboard',
+    'widget_tweaks'
 ]
 
 MIDDLEWARE = [
@@ -193,3 +194,7 @@ LOGGING = {
         },
     },
 }
+
+LOGIN_REDIRECT_URL = '/'
+LOGOUT_REDIRECT_URL = '/accounts/login/'
+LOGIN_URL = '/accounts/login/'

--- a/asset_dashboard/templates/asset_dashboard/base.html
+++ b/asset_dashboard/templates/asset_dashboard/base.html
@@ -41,16 +41,29 @@
       <a class="navbar-brand text-light" href="{% url 'projects' %}">
         Forest Preserves of Cook County
       </a>
-      <div class="nav-item dropdown justify-content-right">
-        <a class="nav-link dropdown-toggle text-light" href="" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          Home
-        </a>
-        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
-          <a class="dropdown-item text-primary" href="{% url 'projects' %}">Projects</a>
-          <a class="dropdown-item text-primary" href="{% url 'cip-planner' %}">CIP Planner</a>
-          <a class="dropdown-item text-primary" href="{% url 'projects-by-district' %}">Projects by District</a>
-          <div class="dropdown-divider"></div>
-          <a class="dropdown-item text-primary" href="{% url 'admin:index' %}">Admin</a>
+
+      <div class="nav-item justify-content-right">
+        {% if user.is_authenticated %}
+          <div class="dropdown">
+            <a class="nav-link dropdown-toggle text-light" href="" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Home
+            </a>
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+              <a class="dropdown-item text-primary" href="{% url 'projects' %}">Projects</a>
+              <a class="dropdown-item text-primary" href="{% url 'cip-planner' %}">CIP Planner</a>
+              <a class="dropdown-item text-primary" href="{% url 'projects-by-district' %}">Projects by District</a>
+              {% if user.is_staff %}
+                <a class="dropdown-item text-primary" href="{% url 'admin:index' %}">Admin</a>
+              {% endif %}
+
+              <div class="dropdown-divider"></div>
+              <a class="dropdown-item text-primary" href="{% url 'logout' %}">Logout</a>
+          </div>
+        {% else %}
+          <a class="nav-link text-light" href="{% url 'login' %}">
+            Login
+          </a>
+        {% endif %}
       </div>
     </nav>
 

--- a/asset_dashboard/templates/registration/login.html
+++ b/asset_dashboard/templates/registration/login.html
@@ -1,0 +1,39 @@
+{% extends 'asset_dashboard/base.html' %}
+{% load static %}
+{% load static widget_tweaks i18n %}
+
+{% block title %}Login{% endblock %}
+
+{% block body %}
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-md-5 bg-white p-5 border rounded shadow-sm">
+                <h2 class="text-center">Login</h2>
+                <form method="POST">
+                    <div class="form-group">
+                        <label for="{{ form.name.id_for_label }}"></label>
+                        <strong>Username</strong>
+                        {% render_field form.username type="text" class+="form-control" %}
+                    </div>
+                    <div class="form-group">
+                        <label for="{{ form.name.id_for_label }}"></label>
+                        <strong>Password</strong>
+                        {% render_field form.password type="password" class+="form-control" %}
+                    </div>
+
+                    {% if form.errors %}
+                        <div class="alert alert-danger text-center">
+                            <strong>Invalid Username/Password</strong>
+                        </div>
+                    {% endif %}
+
+                    <div class="text-center m-2">
+                        {% csrf_token %}
+                        <button type="submit" class="btn btn-primary">Login</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    
+{% endblock %}

--- a/asset_dashboard/urls.py
+++ b/asset_dashboard/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.contrib.auth import views as auth_views
 
 from asset_dashboard.views import ProjectListView, CipPlannerView, ProjectCreateView, \
                                     ProjectUpdateView, ProjectListJson, \
@@ -28,6 +29,8 @@ urlpatterns = [
     path('projects/districts/', ProjectsByDistrictListView.as_view(), name='projects-by-district'),
     path('projects/districts/json/', ProjectsByDistrictListJson.as_view(), name='projects-district-json'),
     path('cip-planner/', CipPlannerView.as_view(), name='cip-planner'),
+    path('accounts/login/', auth_views.LoginView.as_view(), name='login'),
+    path('accounts/logout/', auth_views.LogoutView.as_view(), name='logout'),
     path('admin/', admin.site.urls),
 ]
 

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -13,6 +13,7 @@ from django.contrib import messages
 from django.db.models import Q
 from django.utils.html import escape
 
+
 class CipPlannerView(LoginRequiredMixin, TemplateView):
     title = 'CIP Planner'
     template_name = 'asset_dashboard/planner.html'

--- a/asset_dashboard/views.py
+++ b/asset_dashboard/views.py
@@ -6,14 +6,14 @@ from django.views.generic import TemplateView, ListView, CreateView, UpdateView
 from django_datatables_view.base_datatable_view import BaseDatatableView
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.contrib.auth.mixins import LoginRequiredMixin
 from .models import HouseDistrict, Project, ProjectCategory, ProjectFinances, ProjectScore, Section, SenateDistrict, CommissionerDistrict
 from .forms import ProjectForm, ProjectScoreForm, ProjectCategoryForm, ProjectFinancesForm
 from django.contrib import messages
 from django.db.models import Q
 from django.utils.html import escape
 
-
-class CipPlannerView(TemplateView):
+class CipPlannerView(LoginRequiredMixin, TemplateView):
     title = 'CIP Planner'
     template_name = 'asset_dashboard/planner.html'
     component = 'js/planner.js'
@@ -54,7 +54,7 @@ def server_error(request, template_name='asset_dashboard/500.html'):
     return render(request, template_name, status=500)
 
 
-class ProjectListView(ListView):
+class ProjectListView(LoginRequiredMixin, ListView):
     template_name = 'asset_dashboard/projects.html'
     queryset = Project.objects.all()
     context_object_name = 'projects'
@@ -73,7 +73,7 @@ class ProjectListView(ListView):
         return context
 
 
-class ProjectListJson(BaseDatatableView):
+class ProjectListJson(LoginRequiredMixin, BaseDatatableView):
     model = Project
     columns = ['name', 'description', 'section_owner', 'category', 'id']
     order_columns = ['name', 'description', 'section_owner__name', 'category__category']
@@ -96,7 +96,7 @@ class ProjectListJson(BaseDatatableView):
         return qs
 
 
-class ProjectCreateView(CreateView):
+class ProjectCreateView(LoginRequiredMixin, CreateView):
     template_name = 'asset_dashboard/partials/forms/add_project_modal_form.html'
     form_class = ProjectForm
 
@@ -119,7 +119,7 @@ class ProjectCreateView(CreateView):
             return super().form_invalid(form)
 
 
-class ProjectUpdateView(UpdateView):
+class ProjectUpdateView(LoginRequiredMixin, UpdateView):
     """
     Updated view that updates a Project and all related models.
     """
@@ -171,7 +171,7 @@ class ProjectUpdateView(UpdateView):
         return super().form_valid(form)
 
 
-class ProjectsByDistrictListView(ListView):
+class ProjectsByDistrictListView(LoginRequiredMixin, ListView):
     template_name = 'asset_dashboard/projects_by_district_list.html'
     queryset = Project.objects.all()
     context_object_name = 'projects'
@@ -186,7 +186,7 @@ class ProjectsByDistrictListView(ListView):
         return context
 
 
-class ProjectsByDistrictListJson(BaseDatatableView):
+class ProjectsByDistrictListJson(LoginRequiredMixin, BaseDatatableView):
     model = Project
     columns = ['name', 'description', 'senate_districts', 'house_districts', 'commissioner_districts', 'id']
     order_columns = ['name', 'description']

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ django-compressor
 sentry-sdk
 django-money
 django-datatables-view
+django-widget-tweaks==1.4.8
 
 # Testing requirements
 pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,3 +75,7 @@ def score_weights():
                                               geographic_distance_score=0.5, social_equity_score=0.4,
                                               obligation_weight=0.5, phase_completion=0.5, 
                                               accessibility=0.5, leverage_resource=0.5)
+
+@pytest.fixture
+def user():
+    return models.User.objects.create_user(username='sylvie', password='lightnin')


### PR DESCRIPTION
## Overview
This PR adds authentication to the application. Unauthenticated users can't access or change any data.

Code changes include:
- `LoginRequiredMixin` for the views
- New template for the login page, with some basic styles using the `widget_tweaks` library
- Login and logout urls
- Changes to the menu, including a link to logout and conditional logic based on user auth
- Tests for the authentication

For issue #53.

### Demo
![auth-demo](https://user-images.githubusercontent.com/38969506/110385037-0cfcbc80-8024-11eb-8c7c-0566f190e3b4.gif)

### Notes
This only has authentication and no authorization, so any regular user that's added via the admin site can read, create, and update the data. A regular user won't have access to the admin site.

## Testing Instructions

### test authenticated access
- Create a superuser for the review app: `heroku run python manage.py createsuperuser -a ccfp-asset-d-login-xigkhbpelqo`
- Visit the login page: https://ccfp-asset-d-login-xigkhbpelqo.herokuapp.com/accounts/login/
- Login with your new user. You should be able to access everything, including the admin link in the menu.
- Create a new, non-superuser via the admin site. Login with that user and test the site. You should be able to create, read, and update projects. There should be no menu link to the admin site, nor should you be able to access the admin site.

### test unauthenticated access
- Logout
- Try and visit the different urls, like `/`, `/cip-planner/`, `/projects-by-detail/`. You should be redirected to the login page.
